### PR TITLE
use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,7 +16,7 @@ function Conn() {
 }
 
 Conn.prototype.setApiKey = function(apiKey) {
-	this.options.headers['X-Fastly-Key'] = apiKey;
+	this.options.headers['Fastly-Key'] = apiKey;
 	this.authenticationSet = true;
 }
 

--- a/test/stubs.js
+++ b/test/stubs.js
@@ -2,7 +2,7 @@ var nock   = require('nock');
 
 function createStubs() {
 
-	var goodAuthApi = nock('https://api.fastly.com').matchHeader('X-Fastly-Key', '6ea7c6ed310d436339bc6cfe92265f54')
+	var goodAuthApi = nock('https://api.fastly.com').matchHeader('Fastly-Key', '6ea7c6ed310d436339bc6cfe92265f54')
 
 				// testBackendHealthCheck
 				.get('/service/oOW2G2kwDaaXJVNaaPgpx/version/1/backend/check_all')


### PR DESCRIPTION
The use of `X-Fastly-Key` is deprecated and will not be supported long term. This branch replaces any occurrences of `X-Fastly-Key` with `Fastly-Key`.
